### PR TITLE
Amélioration ajout de mediaType

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ document.addEventListener('deviceready', async function () {
     selectionLimit: 3,   // default 3
     showLoader: true     // default true
     imageOnly: true      // default false
+    mediaType : "all"   // videos, images or all(default all)
   };
 
   try {

--- a/src/android/MediaPicker.java
+++ b/src/android/MediaPicker.java
@@ -32,6 +32,7 @@ public class MediaPicker extends CordovaPlugin {
     private int selectionLimit = 3;
     private boolean showLoader = true;
     private boolean imageOnly = false;
+    private String mediaType = "all"; // images | videos | all
 
     private FrameLayout overlayView;
     private ProgressBar overlaySpinner;
@@ -52,6 +53,12 @@ public class MediaPicker extends CordovaPlugin {
                     selectionLimit = Math.max(1, opts.optInt("selectionLimit", 3));
                     showLoader = opts.optBoolean("showLoader", true);
                     imageOnly = opts.optBoolean("imageOnly", false);
+                    mediaType = opts.optString("mediaType", null);
+
+                    // rétro-compatibilité
+                    if (mediaType == null || mediaType.isEmpty()) {
+                        mediaType = imageOnly ? "images" : "all";
+                    }     
                 }
             }
 
@@ -65,23 +72,44 @@ public class MediaPicker extends CordovaPlugin {
                     intent.putExtra(MediaStore.EXTRA_PICK_IMAGES_MAX, selectionLimit);
                 }
 
-                if (imageOnly) {
-                    intent.setType("image/*");
-                } else {
-                    intent.setType("*/*");
-                    intent.putExtra(Intent.EXTRA_MIME_TYPES, new String[]{"image/*", "video/*"});
+                switch (mediaType) {
+                    case "images":
+                        intent.setType("image/*");
+                        break;
+
+                    case "videos":
+                        intent.setType("video/*");
+                        break;
+
+                    case "all":
+                    default:
+                        intent.setType("*/*");
+                        intent.putExtra(Intent.EXTRA_MIME_TYPES,
+                            new String[]{"image/*", "video/*"});
+                        break;
                 }
+
 
             } else {
                 // ✅ Fallback for Android 10 and below
                 intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
                 intent.addCategory(Intent.CATEGORY_OPENABLE);
 
-                if (imageOnly) {
-                    intent.setType("image/*");
-                } else {
-                    intent.setType("*/*");
-                    intent.putExtra(Intent.EXTRA_MIME_TYPES, new String[]{"image/*", "video/*"});
+               switch (mediaType) {
+                    case "images":
+                        intent.setType("image/*");
+                        break;
+
+                    case "videos":
+                        intent.setType("video/*");
+                        break;
+
+                    case "all":
+                    default:
+                        intent.setType("*/*");
+                        intent.putExtra(Intent.EXTRA_MIME_TYPES,
+                            new String[]{"image/*", "video/*"});
+                        break;
                 }
 
                 intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, selectionLimit > 1);

--- a/src/ios/MediaPicker.swift
+++ b/src/ios/MediaPicker.swift
@@ -12,6 +12,7 @@ class MediaPicker: CDVPlugin, PHPickerViewControllerDelegate {
     private var selectionLimitOpt: Int = 3
     private var showLoaderOpt: Bool = true
     private var imageOnlyOpt: Bool = false
+    private var mediaTypeOpt : String = "all" // ✅ Ajouté
 
     private weak var overlayView: UIView?
     private weak var overlaySpinner: UIActivityIndicatorView?
@@ -24,6 +25,11 @@ class MediaPicker: CDVPlugin, PHPickerViewControllerDelegate {
             if let limit = opts["selectionLimit"] as? Int { selectionLimitOpt = max(1, limit) }
             if let show = opts["showLoader"] as? Bool { showLoaderOpt = show }
             if let imageOnly = opts["imageOnly"] as? Bool { imageOnlyOpt = imageOnly }
+            if let mediaType = opts["mediaType"] as? String { mediaTypeOpt = mediaType }
+            else {
+                // si mediatype n'est pas défini par l'utilisateur, prendre en compte la valeur de imageOnly
+                mediaTypeOpt = imageOnlyOpt ? "images" : "all";
+            }
         }
 
         guard let presentingVC = self.viewController else {
@@ -41,11 +47,23 @@ class MediaPicker: CDVPlugin, PHPickerViewControllerDelegate {
 
         if #available(iOS 14, *) {
             var config = PHPickerConfiguration()
-            if imageOnlyOpt {
-                config.filter = .images
-            } else {
-                config.filter = .any(of: [.images, .videos])
-            }
+            // if imageOnlyOpt {
+            //     config.filter = .images
+            // } else {
+            //     config.filter = .any(of: [.images, .videos])
+            // }
+
+            switch mediaTypeOpt {
+            case "images": config.filter = .images
+            break;
+
+            case "videos" : config.filter = .videos
+            break;
+
+            default:  config.filter = .any(of: [.images, .videos])
+                
+            } 
+
             config.selectionLimit = selectionLimitOpt
 
             let picker = PHPickerViewController(configuration: config)


### PR DESCRIPTION
Ajout de la clé mediaType au JSON envoyé à MediaPicker.getMedias. Contrairement à imageOnly, qui permet de sélectionner uniquement les photos ou les deux (photos et vidéos), mediaType permet également de sélectionner uniquement les vidéos. Valeurs possibles : images, videos ou all. 

Exemple d'implémentation: 
      var MediaPicker = cordova.plugins.MediaPicker;

        const options = {
            selectionLimit: 10,  // nombre max de fichiers
            showLoader: true,
            imageOnly: true,      // false pour autoriser images + vidéos
            mediaType: 'videos' //--- 'images' | 'videos' | 'all'
        };

       const results = await MediaPicker.getMedias(options);